### PR TITLE
Fix preloader load event listener

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -4,8 +4,8 @@
     PRE LOADER
   -------------------------------------------------------------------------------*/
 
-  $(window).load(function(){
-    $('.preloader').fadeOut(1000); // set duration in brackets    
+  $(window).on('load', function() {
+    $('.preloader').fadeOut(1000); // set duration in brackets
   });
 
 


### PR DESCRIPTION
## Summary
- fix preloader script to use `on('load', ...)` instead of deprecated `load`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ef927faf08328988dde68dd5146c4