### PR TITLE
fix: correct typo in home section

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@ http://www.templatemo.com/tm-498-stimulus
                          <div class="section-title">
                               <!-- <h4 class="wow fadeInUp" data-wow-delay="0.3s">welcome to my website</h4> -->
                               <h1 class="wow fadeInUp" data-wow-delay="0.6s">Hi, I am <strong>Danial</strong> currently based in Negeri Sembilan, Malaysia.</h1>
-                              <p class="wow fadeInUp" data-wow-delay="0.9s">I am a graduate software engineer specialised in software architecture with more than 4 years’ experience in digitalising the travel industry. I enjoy problem solving and passionnate to spread software design best practices aiming for an ideal software integration.</p>
+                              <p class="wow fadeInUp" data-wow-delay="0.9s">I am a graduate software engineer specialised in software architecture with more than 4 years’ experience in digitalising the travel industry. I enjoy problem solving and passionate to spread software design best practices aiming for an ideal software integration.</p>
                               <a href="#about" class="wow fadeInUp smoothScroll section-btn btn btn-success" data-wow-delay="1.4s">more</a>
                               
                          </div>


### PR DESCRIPTION
## Summary
- fix typo "passionnate" to "passionate" in the home section description

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689efa862ad48328baab8bbf63f215da