### PR TITLE
docs: expand project overview in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # danialaswad.github.io
+
+Personal website built from the **Stimulus** template by TemplateMo and hosted via GitHub Pages.  
+Everything is pure HTML/CSS/JS—no build steps or server‑side code.
+
+## Structure
+```
+.
+├── index.html   # Main single‑page site
+├── css/         # Bootstrap, animation, and custom styles
+├── js/          # jQuery, plugins, and custom scripts
+├── images/      # Backgrounds and profile images
+├── fonts/       # FontAwesome assets
+└── credits.txt  # Template and asset attributions
+```
+
+## Getting Started
+1. **Preview locally:** open `index.html` in a browser, or run a static server (e.g. `python -m http.server`).
+2. **Customize content:** edit `index.html` and `css/templatemo-style.css` to add your information and styling.
+3. **Deploy:** push changes to `main`—GitHub Pages will serve the site automatically at `https://<username>.github.io/`.
+
+## Credits
+Template: [Stimulus by TemplateMo](https://templatemo.com/tm-485-stimulus)  
+Icons: [FontAwesome](https://fontawesome.com/)  
+See `credits.txt` for full attribution details.
+


### PR DESCRIPTION
## Summary
- document repository structure and static-site workflow
- add quickstart instructions for local preview and deployment
- include template and icon attributions

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ef927ef048328bc8b8e184c7cad20